### PR TITLE
Fix for grunt task wiredep adding the wrong script url in index.html

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "ignore": [
     "app/src",
     ".bowerrc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": {},
   "scripts": {
     "test": "grunt test:dev"


### PR DESCRIPTION
This is a fix for grunt task wiredep adding the wrong script url in index.html
