### PR TITLE
Bump version we need a new tag1.3 in the bower repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "ignore": [
     "app/src",
     ".bowerrc",
@@ -15,10 +15,10 @@
   ],
   "main": "angular-http-loader/app/package/js/angular-http-loader.min.js",
   "devDependencies": {
-    "angular-mocks": ">= 1.2.0 <1.4.0",
-    "angular-scenario": ">= 1.2.0 <1.4.0"
+    "angular-mocks": ">=1.3.x <1.4.0",
+    "angular-scenario": ">=1.3.x <1.4.0"
   },
   "dependencies": {
-    "angular": ">= 1.2.0 <1.4.0"
+    "angular": ">=1.3.x <1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-http-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": {},
   "scripts": {
     "test": "grunt test:dev"


### PR DESCRIPTION
Well from what i can see the [tag v0.1.2](https://github.com/wongatech/angular-http-loader/blob/v0.1.2/bower.json) is actually marked as `"version": "0.1.1"` which should be `0.1.2` with the contents from the [commit](https://github.com/cristobal/angular-http-loader/commit/53c3d7900a80005ca485956f060f4556dd985928), related to the comment in https://github.com/wongatech/angular-http-loader/issues/8. 

However it's good practice to add a new tag instead of fixing the broken `v 0.1.2` so that users get a notice about it, therefore i am bumping the version to `0.1.3` instead. 

Who will make the `tag` so it's automatically fetched and registered by bower?
Or is it automatically created?
