### PR TITLE
Changes to `bower.json` to support `main-bower-files`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "package.json",
     "README.md"
   ],
-  "main": "angular-http-loader/app/package/js/angular-http-loader.min.js",
+  "main": "app/package/js/angular-http-loader.min.js",
   "devDependencies": {
     "angular-mocks": ">= 1.2.0 <1.4.0",
     "angular-scenario": ">= 1.2.0 <1.4.0"


### PR DESCRIPTION
This is necessary with some build systems that read `bower.json` such as `main-bower-files` (https://github.com/ck86/main-bower-files).
