### PR TITLE
Updates method interceptor to run last on http requests

### DIFF
--- a/app/src/js/httpMethodInterceptor.js
+++ b/app/src/js/httpMethodInterceptor.js
@@ -117,5 +117,5 @@ angular
   })
 
   .config(['$httpProvider', function ($httpProvider) {
-    $httpProvider.interceptors.push('httpMethodInterceptor');
+    $httpProvider.interceptors.unshift('httpMethodInterceptor');
   }]);

--- a/app/src/js/httpMethodInterceptor.spec.js
+++ b/app/src/js/httpMethodInterceptor.spec.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach, module, it, inject, jasmine, expect */
+/* global describe, beforeEach, module, it, inject, jasmine, expect, spyOn */
 
 describe('httpMethodInterceptor', function () {
   var httpMethodInterceptor, httpMethodInterceptorProvider, mockQ,
@@ -206,4 +206,23 @@ describe('httpMethodInterceptor', function () {
         expect(res).toBe(response);
       });
   });
+
+  describe('config sets $httpProvider interceptor', function () {
+    var $httpProvider;
+
+    beforeEach(function () {
+      module(function (_$httpProvider_) {
+        $httpProvider = _$httpProvider_;
+        spyOn($httpProvider.interceptors, 'unshift');
+      });
+      module('ng.httpLoader.httpMethodInterceptor');
+      inject();
+    });
+
+    it('should add to $httpProvider interceptors', function () {
+      expect($httpProvider.interceptors.unshift)
+        .toHaveBeenCalledWith('httpMethodInterceptor');
+    });
+  });
 });
+


### PR DESCRIPTION
 - When chaining multiple http interceptors the first interceptor will run last when the request is resolved.  
 - Updating http-loader to allow all other interceptors to run before it does on http response
 - Allows Angular-multimocks and Angular-http-loader to work together